### PR TITLE
update xdebug mode to coverage

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="XDEBUG_MODE" value="coverage"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
         <!-- <env name="DB_CONNECTION" value="sqlite"/> -->


### PR DESCRIPTION
You should have Xdebug installed. If not go to: https://xdebug.org/wizard
In your command prompt run "php -i "
Then past it to the box 
By doing this, the Xdebug wizard will show you the compatible version to install and how to do that
PS: Only do this if Xdebug is not already installed, you can check by running "php --info | grep xdebug"