### PR TITLE
test(auth): Add feature tests for password reset functionality

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,12 +23,13 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+
         return [
 
-            'firstName' => $this->faker->firstName,
-            'lastName' => $this->faker->lastName,
-            'userName' => $this->faker->unique()->userName,
-            'email' => $this->faker->unique()->safeEmail,
+            'firstName' => $this->faker->firstName(),
+            'lastName' => $this->faker->lastName(),
+            'userName' => $this->faker->unique()->userName(),
+            'email' => $this->faker->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => Hash::make('password123@'), // or Hash::make('password')
             'remember_token' => Str::random(10),

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,8 +32,7 @@ Route::prefix('v1')->group(function () {
 
     Route::middleware(['jwtAuth'])->group(function () {
         //Protected routes
-       
-            Route::post('auth/logout',[AuthController::class, 'logout']);
+        Route::post('auth/logout',[AuthController::class, 'logout']);
 
         Route::resource('/users',UserController::class);
         Route::resource('/tasks',TaskController::class);

--- a/tests/Feature/Auth/AutorizationTest.php
+++ b/tests/Feature/Auth/AutorizationTest.php
@@ -23,7 +23,7 @@ it("access with invalid or expired JWT token", function () {
 
 it("acces with valid JWT toke",function(){
 
-    $user=User::factory()->create();
+    $user = User::factory()->create()->fresh();
 
     $token=JWTAuth::fromUser($user);
 

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Notification;
+use Faker\Factory as Faker;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use function Pest\Laravel\postJson;
+
+beforeEach(function () {
+    Notification::fake();
+});
+
+test("A valid user can request a password reset link", function () {
+    $user = User::factory()->create()->fresh();
+
+    $this->postJson('/api/v1/auth/password/email', ['email' => $user->email])
+        ->assertStatus(200)
+        ->assertJson([
+            'status' => 'success',
+            'message' => 'Password reset link sent successfully. Please check your email.'
+        ]);
+
+    Notification::assertSentTo($user, ResetPassword::class);
+    $this->assertDatabaseHas('password_reset_tokens', [
+        'email' => $user->email
+    ]);
+});
+
+test('Email not found', function () {
+    $email = Faker::create()->safeEmail();
+
+    $this->postJson('/api/v1/auth/password/email', ['email' => $email])
+        ->assertStatus(200)
+        ->assertJson([
+            'status' => 'success',
+            'message' => 'Password reset link sent successfully. Please check your email.'
+        ]);
+
+    Notification::assertNothingSent();
+    $this->assertDatabaseMissing('password_reset_tokens', ['email' => $email]);
+});

--- a/tests/Feature/Auth/TokenRefreshTest.php
+++ b/tests/Feature/Auth/TokenRefreshTest.php
@@ -34,18 +34,7 @@ it('returns new tokens and invalidates old refresh token', function () {
 
     // 8. Try using old refresh token again (simulate replay attack)
     $this->withHeader('Authorization', "Bearer $originalRefreshToken")
-         ->postJson('/api/v1/auth/refresh')
-         ->assertUnauthorized()
-         ->assertJson(['error' => 'Could not refresh token']);
+        ->postJson('/api/v1/auth/refresh')
+        ->assertUnauthorized()
+        ->assertJson(['error' => 'Could not refresh token']);
 });
-
-/* it('returns 401 Unauthorized for an invalid refresh token', function () {
-    // Generate a random, invalid token string
-    $invalidToken = 'invalid-refresh-token-string-12345';
-
-    $response = $this->withHeader('Authorization', "Bearer $invalidToken")
-                     ->postJson('/api/v1/auth/refresh');
-
-    $response->assertStatus(401)
-             ->assertJson(['message' => 'Unauthenticated.']); // Or your specific error message
-}); */

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -15,7 +15,7 @@ use Tests\TestCase;
 */
 
 uses(TestCase::class, RefreshDatabase::class)->in('Feature');
-
+uses(TestCase::class, RefreshDatabase::class)->in('Unit');
 /*
 |--------------------------------------------------------------------------
 | Expectations

--- a/tests/Unit/Auth/ForgotPasswordControllerTest.php
+++ b/tests/Unit/Auth/ForgotPasswordControllerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Http\Controllers\Auth\ForgotPasswordController;
+use App\Http\Requests\Auth\ForgotPasswordRequest;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Validation\ValidationException;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Faker\Factory as Faker;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function () {
+    // Make sure no real façade calls happen
+    Password::clearResolvedInstances();
+});
+
+it('returns a 200 JSON response when sendResetLink succeeds', function () {
+    $email = Faker::create()->safeEmail();
+
+    // 1) Fake a FormRequest whose validated() returns our email
+    $request = Mockery::mock(ForgotPasswordRequest::class);
+    $request->shouldReceive('validated')->once()->andReturn(['email' => $email]);
+    $request->shouldReceive('all')->andReturn(['email' => $email]);
+    $request->shouldReceive('wantsJson')->andReturn(true);
+
+    // 2) Mock Password façade to return the “sent” constant
+    Password::shouldReceive('sendResetLink')
+        ->once()
+        ->with(['email' => $email])
+        ->andReturn(Password::RESET_LINK_SENT);
+
+    // 3) Call
+    $controller = new ForgotPasswordController();
+    $response = $controller->sendResetLinkEmail($request);
+
+    // 4) Assert it’s exactly the JSON you expect
+    expect($response)
+        ->toBeInstanceOf(JsonResponse::class)
+        ->and($response->getStatusCode())->toBe(200)
+        ->and($response->getData(true))->toMatchArray([
+            'status'  => 'success',
+            'message' => 'Password reset link sent successfully. Please check your email.',
+        ]);
+});
+
+
+it("Successfully stores the token in the database", function () {
+    // 1) Arrange a real user and fake notifications
+    $user = User::factory()->create();
+    Notification::fake();
+
+    // 2) Mock only the FormRequest so it returns our email
+    $request = Mockery::mock(ForgotPasswordRequest::class);
+    $request->shouldReceive('validated')->once()->andReturn(['email' => $user->email]);
+    $request->shouldReceive('wantsJson')->andReturn(true);
+
+    // 3) Stub Password::sendResetLink to both insert a row and queue a notification
+    // In the 'Successfully stores the token in the database' test
+    Password::shouldReceive('sendResetLink')
+        ->once()
+        ->with(['email' => $user->email])
+        // CHANGE THIS LINE
+        ->andReturnUsing(function (array $credentials) use ($user) {
+            // Now you can access the email like this:
+            $email = $credentials['email'];
+
+            // simulate the broker writing a DB record
+            $token = Str::random(64);
+            DB::table('password_reset_tokens')->insert([
+                'email'      => $email,
+                'token'      => hash('sha256', $token),
+                'created_at' => now(),
+            ]);
+
+            // simulate the broker firing the notification
+            Notification::send($user, new ResetPassword($token));
+
+            return Password::RESET_LINK_SENT;
+        });
+
+    // 4) Act: call your controller
+    $response = (new ForgotPasswordController())->sendResetLinkEmail($request);
+
+    // 5) Assert: correct JsonResponse
+    expect($response)
+        ->toBeInstanceOf(JsonResponse::class)
+        ->and($response->getStatusCode())->toBe(200)
+        ->and($response->getData(true))->toMatchArray([
+            'status'  => 'success',
+            'message' => 'Password reset link sent successfully. Please check your email.',
+        ]);
+
+    // 6) Assert: token row is in the database
+    $this->assertDatabaseHas('password_reset_tokens', [
+        'email' => $user->email,
+    ]);
+
+    // 7) Assert: notification was sent
+    Notification::assertSentTo($user, ResetPassword::class);
+});


### PR DESCRIPTION
- Added a new feature test file for the `/auth/password/email` endpoint.
- Includes a test for a successful password reset request from a valid user.
- Includes a test for a non-existent email address that confirms the new, secure behavior.
- These tests verify the full request-response cycle and database state.